### PR TITLE
Modificación del mixin grid: parametros y adaptacion a cualquier breakpoints establecido en el config.scss

### DIFF
--- a/components/_css-core.scss
+++ b/components/_css-core.scss
@@ -23,8 +23,8 @@
   @include cssFlexColumnReverse();
 
   //grids
-  .grid-container.grid-1234 { @include grid('.grid-item', 1, 2, 3, 4, 1em) }
-  .grid-container.grid-2345 { @include grid('.grid-item', 2, 3, 4, 5, 1em) }
+  .grid-container.grid-1234 { @include grid('.grid-item', (1, 2, 3, 4)) }
+  .grid-container.grid-2345 { @include grid('.grid-item', (2, 3, 4, 5)) }
 
   // devMode
   body.dev,

--- a/components/_grid.scss
+++ b/components/_grid.scss
@@ -17,12 +17,23 @@
   }
 }
 
-// create grid
-// params: selector (quoted string)
-// $s, $m, $l, $xl -> number of columns in each breakpoint
-// gutter -> gutter between grid items
-@mixin grid($selector,$s,$m:$s,$l:$m,$xl:$l,$gutter:1em){
-  $width       : 100% / $s;
+/*
+| Mixin para crear cuadriculas
+|
+| $selector: nombre del selector CSS de cada item de la cuadricula
+|
+| $listColumns: 
+|              * lista de numeros de columnas en cada breakpoint. Ej: (1,2,3,4)
+|              * usar parenteris "()" si la lista contiene mas de un elemento
+|              * el numero de columnas del ultimo breakpoint se hereda a breakpoints superiores
+|
+| $gutter: separación entre cada item de la cuadricula (opcional)
+|
+*/
+
+@mixin grid($selector,$listColumns,$gutter:1em){
+
+  $width       : 100% / nth($listColumns,1);
   display      : flex;
   flex-wrap    : wrap;
   margin-left  : -($gutter / 2);
@@ -53,7 +64,12 @@
   }
 
   // calculate grid item width for each breakpoint
-  @include columnWidth($m,$s,m,$gutter,$selector);    // medium
-  @include columnWidth($l,$m,l,$gutter,$selector);    // large
-  @include columnWidth($xl,$l,xl,$gutter,$selector);  // xlarge
+  $indice: 1;
+  $longListColumns: length($listColumns);
+  @each $size, $_ in $breakpoints{
+    @if $indice > 1 and $indice <= $longListColumns{
+      @include columnWidth(nth($listColumns,$indice),nth($listColumns,$indice - 1),$size,$gutter,$selector);
+    }
+    $indice: $indice + 1;
+  }
 }


### PR DESCRIPTION
Las columnas de cada breakpoints son pasadas al mixin como una lista, y se evita tener que estar configurando el mixin al agregar breakpoints personales.

Los calculos para cada breakpoints se realizan de acuerdo a la cantidad de breakpoints establecidos en el config.scss de forma automatica.

Ademas soluciona un problema que existe al querer establecer un gutter de tamaño personal,ya que obligatoriamente habia que enviarle al mixin todos los  numeros de columnas para cada breakpoints existente, para asi al final del parametro enviarle el gutter.