### PR TITLE
Actualizada la version en el package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ed-grid",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Framework de CSS puro para crear diseños web responsive y mobile first.",
   "style": "ed-grid.scss",
   "main": "ed-grid.scss",


### PR DESCRIPTION
Hola Álvaro, creo que la versión que figura en el package.json esta desactualizada, no se bien que versión es la mas actual de ed-grid, por eso le pongo la 2.0.0. Lo tuve que hacer porque al documentar el framework con sassdoc me arroja en grande la versión 1.3 y eso puede llegar a confundir a mucha gente.